### PR TITLE
Fix quiet attacks for Survivor Combatives.

### DIFF
--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -30,8 +30,10 @@
                 "id" : "style_surv_quite",
                 "name" : "Quiet Combat",
                 "unarmed_allowed" : true,
+                "melee_allowed" : true,
                 "min_unarmed" : 4,
                 "min_melee" : 4,
+                "quiet" : true,
                 "description" : "User has learned how to deal all attacks quietly"
             },
 			{


### PR DESCRIPTION
The silent buff on survivor combatives "martial art" was not making attacks silent. Furthermore, it was only active in unarmed attacks when it should be all attacks. This PR fixes that.