### PR TITLE
Added smoked glass welding goggle recipe option

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -5869,5 +5869,22 @@
         ]
       ]
     ]
+  },
+  {
+    "result": "goggles_welding",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "mechanics",
+    "difficulty": 2,
+    "skills_required": [ "fabrication", 1 ],
+    "time": 30000,
+    "autolearn": true,
+    "book_learn": [ [ "textbook_fabrication", 3 ], [ "welding_book", 3 ] ],
+    "tools": [ [ [ "spray_can", 1 ], [ "char_smoker", 25 ] ] ],
+    "components": [
+      [ [ "goggles_ski", 1 ], [ "goggles_swim", 1 ], [ "glasses_safety", 1 ], [ "sunglasses", 1 ] ],
+      [ [ "duct_tape", 20 ], [ "medical_tape", 20 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
Welding goggles can be now crafted using charcoal smoker as well. Identical to my PR to core at https://github.com/CleverRaven/Cataclysm-DDA/pull/20891