### PR TITLE
Update mod for release.

### DIFF
--- a/Monsters/c_monsters.json
+++ b/Monsters/c_monsters.json
@@ -483,7 +483,7 @@
       {
         "type": "gun",
         "cooldown": 5,
-        "gun_type": "bio_blaster_gun",
+        "gun_type": "laser_lmg",
         "ammo_type": "generic_no_ammo",
         "max_ammo": 1000,
         "fake_str": 8,
@@ -503,12 +503,12 @@
         "targeting_cost": 200,
         "ranges": [
           [
-            20,
+            15,
             30,
             "DEFAULT"
           ]
         ],
-        "description": "The super soldier fires its fusion blaster!",
+        "description": "The super soldier fires its lmg!",
         "targeting_sound": "swoosh...click!",
         "targeting_volume": 20,
         "no_ammo_sound": "beep-beep-beep!"
@@ -600,7 +600,7 @@
           ]
         ],
         "description": "The super scout fires its rifle!",
-        "targeting_sound": "arrrrrgh!",
+        "targeting_sound": "hhhmmmmm",
         "targeting_volume": 5,
         "no_ammo_sound": "beep-beep-beep!"
       }

--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -910,36 +910,6 @@
   },
   {
     "type": "recipe",
-    "result": "goo_jerrycan",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_OTHER",
-    "difficulty": 0,
-    "time": 2000,
-    "reversible": false,
-    "autolearn": true,
-    "book_learn": [
-      [
-        "recipe_surv",
-        0
-      ]
-    ],
-    "components": [
-      [
-        [
-          "jerrycan",
-          1
-        ]
-      ],
-      [
-        [
-          "gas_slime_scrap",
-          10
-        ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "molded_saw",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
@@ -5614,76 +5584,6 @@
   },
   {
     "type": "recipe",
-    "result": "solar_recharger",
-    "category": "CC_ELECTRONIC",
-    "skill_used": "electronics",
-    "skills_required": [
-      "fabrication",
-      3
-    ],
-    "difficulty": 4,
-    "time": 15000,
-    "reversible": false,
-    "autolearn": false,
-    "book_learn": [
-      [
-        "manual_electronics",
-        2
-      ],
-      [
-        "mag_electronics",
-        2
-      ],
-      [
-        "manual_electronics",
-        2
-      ],
-      [
-        "recipe_surv",
-        1
-      ]
-    ],
-    "tools": [
-      [
-        [
-          "soldering_iron",
-          25
-        ],
-        [
-          "toolset",
-          25
-        ]
-      ]
-    ],
-    "components": [
-      [
-        [
-          "sheet_metal",
-          1
-        ]
-      ],
-      [
-        [
-          "solar_cell",
-          4
-        ]
-      ],
-      [
-        [
-          "solder_wire",
-          2
-        ]
-      ],
-      [
-        [
-          "scrap",
-          2
-        ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "mil_surp_pack_1",
     "id_suffix": "uncraft",
     "category": "CC_NONCRAFT",
@@ -5934,18 +5834,6 @@
     "time" : 1,
     "pre_terrain" : "f_fridge_unplugged",
     "post_terrain" : "f_fridge"
-  },{
-    "result": "gasoline",
-    "type" : "recipe",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_FUEL",
-    "skill_used": "cooking",
-    "difficulty": 1,
-	"result_mult": 4,
-	"autolearn": true,
-    "time": 60,
-     "tools":[[ [ "goo_jerrycan", 24 ]]],
-	 "components":[[["water", 1]]]
   },
   {
     "type" : "recipe",
@@ -5966,6 +5854,98 @@
     "components": [
       [ [ "fridge", 1 ] ],
       [ [ "power_supply", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "unbio_sword_weapon",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "electronics",
+    "skills_required": [
+      "fabrication",
+      4,
+      "melee",
+      2
+    ],
+    "difficulty": 6,
+    "time": 30000,
+    "reversible": false,
+    "autolearn": false,
+    "book_learn": [
+      [
+        "recipe_lab_elec",
+        5
+      ]
+    ],
+    "qualities": [
+      {
+        "id": "SCREW_FINE",
+        "level": 1,
+        "amount": 1
+      }
+    ],
+    "tools": [
+      [
+        [
+          "soldering_iron",
+          20
+        ],
+        [
+          "toolset",
+          20
+        ],
+        [
+          "small_repairkit",
+          20
+        ],
+        [
+          "large_repairkit",
+          10
+        ]
+      ],
+      [
+        [
+          "oxy_torch",
+          25
+        ],
+        [
+          "welder",
+          85
+        ],
+        [
+          "welder_crude",
+          180
+        ],
+        [
+          "toolset",
+          180
+        ]
+      ]
+    ],
+    "components": [
+      [
+        [
+          "bio_sword",
+          1
+        ]
+      ],
+      [
+        [
+          "steel_chunk",
+          3
+        ],
+        [
+          "scrap",
+          9
+        ]
+      ],
+      [
+        [
+          "plastic_chunk",
+          3
+        ]
+      ]
     ]
   }
 ]

--- a/Surv_help/c_bionics.json
+++ b/Surv_help/c_bionics.json
@@ -91,7 +91,7 @@
       "WBLOCK_2"
     ],
     "volume": 9,
-    "cutting": 36,
+    "cutting": 48,
     "flags": [
       "NON_STUCK",
       "NO_UNWIELD",

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -222,7 +222,7 @@
       "bio_blade_weapon",
       "bio_sword_weapon",
       "unbio_bladed_weapon",
-			"unbio_sword_weapon",
+      "unbio_sword_weapon",
       "unbio_claws_weapon"
     ]
   },
@@ -233,7 +233,7 @@
         "name" : "Bionic Combatives",
         "weapons" : [
             "unbio_bladed_weapon",
-			      "unbio_sword_weapon",
+	    "unbio_sword_weapon",
             "unbio_claws_weapon",
             "bio_sword_weapon",
             "bio_claws_weapon",

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -231,7 +231,7 @@
         "weapons" : [
             "unbio_bladed_weapon",
             "unbio_claws_weapon",
-			"bio_sword_weapon",
+            "bio_sword_weapon",
             "bio_claws_weapon",
             "bio_blade_weapon"
         ]

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -222,5 +222,18 @@
       "bio_blade_weapon",
       "bio_sword_weapon"
     ]
-  }
+  },
+  {
+        "type" : "martial_art",
+        "id" : "style_biojutsu",
+        "copy-from" : "style_biojutsu",
+        "name" : "Bionic Combatives",
+        "weapons" : [
+            "unbio_bladed_weapon",
+            "unbio_claws_weapon",
+			"bio_sword_weapon",
+            "bio_claws_weapon",
+            "bio_blade_weapon"
+        ]
+    }
 ]

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -220,7 +220,10 @@
       "PR24-extended",
       "bio_claws_weapon",
       "bio_blade_weapon",
-      "bio_sword_weapon"
+      "bio_sword_weapon",
+      "unbio_bladed_weapon",
+			"unbio_sword_weapon",
+      "unbio_claws_weapon"
     ]
   },
   {
@@ -230,6 +233,7 @@
         "name" : "Bionic Combatives",
         "weapons" : [
             "unbio_bladed_weapon",
+			      "unbio_sword_weapon",
             "unbio_claws_weapon",
             "bio_sword_weapon",
             "bio_claws_weapon",

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -711,28 +711,6 @@
     "to_hit": -1
   },
   {
-    "id": "solar_recharger",
-    "type": "TOOL",
-    "symbol": ",",
-    "color": "light_gray",
-    "name": "Solar Battery Recharger",
-    "description": "A makeshift solar battery recharger made from a modified rechargeable battery mod. Input batteries, put in the sun, batteries charge, take them out, simple.",
-    "price": 200,
-    "material": "steel",
-    "weight": 283,
-    "volume": 5,
-    "to_hit": 0,
-    "max_charges": 100,
-    "initial_charges": 0,
-    "charges_per_use": 0,
-    "turns_per_charge": 0,
-    "ammo": "battery",
-    "revert_to": "null",
-    "artifact_data": {
-      "charge_type": "ARTC_SOLAR"
-    }
-  },
-  {
     "id": "solar_torch",
     "type": "TOOL",
     "symbol": "/",
@@ -828,40 +806,6 @@
     "phase": "solid",
     "charges": 1,
     "fun": -10
-  },
-  {
-    "id": "goo_jerrycan",
-    "type": "TOOL_ARMOR",
-    "covers": [
-      "TORSO"
-    ],
-    "warmth": 5,
-    "encumbrance": 30,
-    "flags": [
-      "OVERSIZE",
-      "BELTED"
-    ],
-    "coverage": 40,
-    "material_thickness": 2,
-    "symbol": ")",
-    "color": "light_red",
-    "name": "Goo jerrycan",
-    "category": "other",
-    "description": "A former plastic jerrycan taken over by the gasoline goo. Now it fills the jerry can with gasoline when exposed to the sun. Unload to enjoy!",
-    "price": 1250,
-    "weight": 1854,
-    "volume": 40,
-    "to_hit": -2,
-    "material": "plastic",
-    "max_charges": 10000,
-    "initial_charges": 0,
-    "charges_per_use": 0,
-    "turns_per_charge": 0,
-    "ammo": "gasoline",
-    "revert_to": "null",
-    "artifact_data": {
-      "charge_type": "ARTC_SOLAR"
-    }
   },
   {
     "id": "molded_saw",

--- a/Vehicles/c_vehicles.json
+++ b/Vehicles/c_vehicles.json
@@ -1412,26 +1412,14 @@
       {
         "x": -7,
         "y": 1,
-        "chance": 20,
+        "chance": 50,
         "items": "survivormap"
       },
       {
         "x": -7,
         "y": 2,
-        "chance": 30,
-        "items": "surv_full_223"
-      },
-      {
-        "x": -7,
-        "y": 2,
-        "chance": 30,
-        "items": "reloaded_223"
-      },
-      {
-        "x": -7,
-        "y": 2,
-        "chance": 30,
-        "items": "surv_lmg_223"
+        "chance": 50,
+        "items": [ "surv_lmg_223", "surv_belt_223", "reloaded_223", "reloaded_223", "reloaded_223" ]
       }
     ]
   },

--- a/Weapons/c_melee.json
+++ b/Weapons/c_melee.json
@@ -1,9 +1,9 @@
 [
   {
-    "type": "GENERIC",
+    "type": "TOOL",
     "id": "unbio_bladed_weapon",
-    "name": "monomolecular sword",
-    "description": "A foot-long sword made from high-tech alloy and edged with bonded nanocrystals. A welded metal handle and handguard allow you to hold it without slicing your hand open.",
+    "name": "monomolecular knife",
+    "description": "A foot-long knife made from high-tech alloy and edged with bonded nanocrystals. A welded metal handle and handguard allow you to hold it without slicing your hand open.",
     "weight": 250,
     "to_hit": 3,
     "color": "dark_gray",
@@ -21,7 +21,8 @@
     "flags": [
       "NON_STUCK",
       "STAB",
-      "UNBREAKABLE_MELEE"
+      "UNBREAKABLE_MELEE", 
+      "SHEATH_KNIFE"
     ],
     "price": 420000,
     "qualities": [
@@ -33,10 +34,62 @@
         "BUTCHER",
         22
       ]
-    ]
+    ],
+    "gunmod_data": {
+      "location": "underbarrel",
+      "mod_targets": [ "shotgun", "rifle", "smg", "crossbow" ],
+      "dispersion_modifier": 8,
+      "mode_modifier": [ [ "REACH", "bayonet", 2, [ "MELEE" ] ] ],
+      "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ]
+    }
   },
   {
-    "type": "GENERIC",
+    "type": "TOOL",
+    "id": "unbio_sword_weapon",
+    "name": "monomolecular sword",
+    "description": "A yard-long sword made from high-tech alloy and edged with bonded nanocrystals. A welded metal handle and handguard allow you to hold it without slicing your hand open.",
+    "weight": 250,
+    "to_hit": 3,
+    "color": "dark_gray",
+    "symbol": "{",
+    "material": [
+      "superalloy",
+      "steel"
+    ],
+    "techniques": [
+      "RAPID",
+      "WBLOCK_2"
+    ],
+    "volume": 10,
+    "bashing": 8,
+    "cutting": 48,
+    "flags": [
+      "NON_STUCK",
+      "STAB",
+      "UNBREAKABLE_MELEE", 
+      "SHEATH_SWORD"
+    ],
+    "price": 420000,
+    "qualities": [
+      [
+        "CUT",
+        1
+      ],
+      [
+        "BUTCHER",
+        22
+      ]
+    ],
+    "gunmod_data": {
+      "location": "underbarrel",
+      "mod_targets": [ "shotgun", "rifle" ],
+      "dispersion_modifier": 10,
+      "mode_modifier": [ [ "REACH", "bayonet", 2, [ "MELEE" ] ] ],
+      "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ]
+    }
+  },
+  {
+    "type": "TOOL",
     "id": "unbio_claws_weapon",
     "name": "bionic claw knuckles",
     "name_plural": "bionic claw knuckles",

--- a/removed.txt
+++ b/removed.txt
@@ -1,0 +1,181 @@
+,{
+    "result": "gasoline",
+    "type" : "recipe",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_FUEL",
+    "skill_used": "cooking",
+    "difficulty": 1,
+	"result_mult": 4,
+	"autolearn": true,
+    "time": 60,
+     "tools":[[ [ "goo_jerrycan", 24 ]]],
+	 "components":[[["water", 1]]]
+  },{
+    "result": "battery",
+    "type" : "recipe",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_FUEL",
+    "skill_used": "cooking",
+    "difficulty": 1,
+	"result_mult": 4,
+	"autolearn": true,
+    "time": 60,
+     "tools":[[ [ "solar_recharger", 100 ]]]
+  },
+  {
+    "id": "goo_jerrycan",
+    "type": "TOOL_ARMOR",
+    "covers": [
+      "TORSO"
+    ],
+    "warmth": 5,
+    "encumbrance": 30,
+    "flags": [
+      "OVERSIZE",
+      "BELTED"
+    ],
+    "coverage": 40,
+    "material_thickness": 2,
+    "symbol": ")",
+    "color": "light_red",
+    "name": "Goo jerrycan",
+    "category": "other",
+    "description": "A former plastic jerrycan taken over by the gasoline goo. Now it fills the jerry can with gasoline when exposed to the sun. Unload to enjoy!",
+    "price": 1250,
+    "weight": 1854,
+    "volume": 40,
+    "to_hit": -2,
+    "material": "plastic",
+    "max_charges": 10000,
+    "initial_charges": 0,
+    "charges_per_use": 0,
+    "turns_per_charge": 0,
+    "ammo": "gasoline",
+    "revert_to": "null",
+    "artifact_data": {
+      "charge_type": "ARTC_SOLAR"
+    }
+  },
+  {
+    "id": "solar_recharger",
+    "type": "TOOL",
+    "symbol": ",",
+    "color": "light_gray",
+    "name": "Solar Battery Recharger",
+    "description": "A makeshift solar battery recharger made from a modified rechargeable battery mod. Input batteries, put in the sun, batteries charge, take them out, simple.",
+    "price": 200,
+    "material": "steel",
+    "weight": 283,
+    "volume": 5,
+    "to_hit": 0,
+    "max_charges": 100,
+    "initial_charges": 0,
+    "charges_per_use": 0,
+    "turns_per_charge": 0,
+    "ammo": "battery",
+    "revert_to": "null",
+    "artifact_data": {
+      "charge_type": "ARTC_SOLAR"
+    }
+  },
+  {
+    "type": "recipe",
+    "result": "goo_jerrycan",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "difficulty": 0,
+    "time": 2000,
+    "reversible": false,
+    "autolearn": true,
+    "book_learn": [
+      [
+        "recipe_surv",
+        0
+      ]
+    ],
+    "components": [
+      [
+        [
+          "jerrycan",
+          1
+        ]
+      ],
+      [
+        [
+          "gas_slime_scrap",
+          10
+        ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "solar_recharger",
+    "category": "CC_ELECTRONIC",
+    "skill_used": "electronics",
+    "skills_required": [
+      "fabrication",
+      3
+    ],
+    "difficulty": 4,
+    "time": 15000,
+    "reversible": false,
+    "autolearn": false,
+    "book_learn": [
+      [
+        "manual_electronics",
+        2
+      ],
+      [
+        "mag_electronics",
+        2
+      ],
+      [
+        "manual_electronics",
+        2
+      ],
+      [
+        "recipe_surv",
+        1
+      ]
+    ],
+    "tools": [
+      [
+        [
+          "soldering_iron",
+          25
+        ],
+        [
+          "toolset",
+          25
+        ]
+      ]
+    ],
+    "components": [
+      [
+        [
+          "sheet_metal",
+          1
+        ]
+      ],
+      [
+        [
+          "solar_cell",
+          4
+        ]
+      ],
+      [
+        [
+          "solder_wire",
+          2
+        ]
+      ],
+      [
+        [
+          "scrap",
+          2
+        ]
+      ]
+    ]
+  }
+  


### PR DESCRIPTION
Had to remove the solar battery recharger and gasoline producing jerrycan since changes in definitions made them no longer work. #41 tried to make it work but apart from it being a patch it did not really work all that well since it was very situational.

Previously the standalone Monomolecular Sword was made a from a Monomolecular Blade CBM and had the stats of such with an incorrect description. I fixed that and added a Monomolecular Blade version. Both versions can also be used a bayonets as an underbarrel mod.

Either by mistake of intent (I don't actually recall...) The zombie super juggernaut had a fusion blaster rather than the LMG it was intended to have cause a few premature ends to players... This monster now has the LMG instead of the Blaster.

If a survivor finds the Survivor RV they would sometimes find one of the Makeshift firearms (.223 LMG) but no magazine for it...that is because there wasn't one define so they could not shoot the gun. I added the ammo belt for it so if they find the RV with the gun then they will be able to fire it.

Fixed Survivor Combatives and Bionic Combatives not having all (un)bionic melee weapons.