### PR TITLE
Fixes typos and scenarios

### DIFF
--- a/Char_creation/c_classes_bw.json
+++ b/Char_creation/c_classes_bw.json
@@ -976,7 +976,7 @@
     "type": "profession",
     "ident": "sf_blade",
     "name": "Slave Fighter (Blade)",
-    "description": "Your were augmented with a blade, and enhancements to your speed and reaction time. You can hit an opponent multiple times before they land a blow.",
+    "description": "You were augmented with a blade, and enhancements to your speed and reaction time. You can hit an opponent multiple times before they land a blow.",
     "points": 6,
     "CBMs": [
       "bio_sword",
@@ -1029,7 +1029,7 @@
     "type": "profession",
     "ident": "sf_claw",
     "name": "Slave Fighter (Claws)",
-    "description": "Your were augmented with some claws, and enhancements to your reflexes. You deliver a powerful strike that neutralizes foes in few hits.",
+    "description": "You were augmented with some claws, and enhancements to your reflexes. You deliver a powerful strike that neutralizes foes in few hits.",
     "points": 6,
     "CBMs": [
       "bio_claws",
@@ -1089,7 +1089,7 @@
     "type": "profession",
     "ident": "sf_shock",
     "name": "Slave Fighter (Shocker)",
-    "description": "Your were augmented with electrical generators and protection from them. You hit multiple foes with electricity multiple times until their nervous system gives up.",
+    "description": "You were augmented with electrical generators and protection from them. You hit multiple foes with electricity, frying them until their nervous system gives up.",
     "points": 6,
     "CBMs": [
       "bio_chain_lightning",
@@ -1141,7 +1141,7 @@
     "type": "profession",
     "ident": "sf_weapon",
     "name": "Slave Fighter (Weapon Master)",
-    "description": "You have been augmented with many 'passive' combat bionics, they merely aid you but are not weapons in and of themselves. You have been trained to use all sorts of different weapons, including your fists, and you have learned. You can pretty much weaponize a sock.",
+    "description": "You have been augmented with many 'passive' combat bionics, they merely aid you but are not weapons in and of themselves. You have been trained to use all sorts of different weapons, including your fists. You can pretty much weaponize a sock.",
     "points": 6,
     "traits": [
       "MARTIAL_ARTS_SURV"

--- a/Char_creation/c_classes_r.json
+++ b/Char_creation/c_classes_r.json
@@ -3,7 +3,7 @@
     "type": "profession",
     "ident": "can_sur",
     "name": "Canned Survivor",
-    "description": "You were a very busy person. That's why you bought a can of survival items and called it a day. Now its the only thing you have.",
+    "description": "You were a very busy person. That's why you bought a can of survival items and called it a day. Now it's the only thing you have.",
     "points": 1,
     "items": {
       "both": [
@@ -105,7 +105,7 @@
     "type": "profession",
     "ident": "prepper",
     "name": "Prepper",
-    "description": "You were paranoid about the world ending so you jumped on the prepper bandwagon. You read a book on survival and got yourself a gun pack and a some gear. The cataclysm was not what you expected.",
+    "description": "You were paranoid about the world ending so you jumped on the prepper bandwagon. You read a book on survival and got yourself a gun pack and some gear. The cataclysm was not what you expected.",
     "points": 5,
     "skills": [
       {

--- a/Char_creation/c_scenarios.json
+++ b/Char_creation/c_scenarios.json
@@ -4,7 +4,7 @@
     "ident": "bunker",
     "name": "Bunker Evacuee",
     "points": 2,
-    "description": "You had connections, or intel somehow..., and because of it, you found this LMOE Shelter. Its summer now and you somehow survived and now things got a little bit easier.",
+    "description": "You had connections, or intel somehow..., and because of it, you found this LMOE Shelter. It's summer now and you somehow survived, now things get a little bit easier.",
     "allowed_locs": [
       "lmoe"
     ],
@@ -31,7 +31,7 @@
     "ident": "bugout",
     "name": "Into the Wild",
     "points": -2,
-    "description": "You tried to make it in the cities, you truly did. Things only got worse and you had to leave. You have skills to live in the woods, so that's where you headed. Its autumn now... winter is coming... they lurk by the trees... time to rebuild...",
+    "description": "You tried to make it in the cities, you truly did. Things only got worse and you had to leave. You have skills to live in the woods, so that's where you are headed. It's autumn now... winter is coming... they lurk by the trees... time to rebuild...",
     "start_name": "Forest",
     "professions": [
       "naturalist",
@@ -178,7 +178,7 @@
     "ident": "mycus_bwmd",
     "name": "Mycus B.W.M.D",
     "points": 2,
-    "description": "After mycus assimilation was successful, our local system was instructed to claim more territory for the mycus. Hostile organism are near, proceed with caution.",
+    "description": "After mycus assimilation was successful, our local system was instructed to claim more territory for the mycus. Hostile organisms are near, proceed with caution.",
     "start_name": "Fungal Territory",
     "professions": [
       "mycus_weapon"
@@ -299,7 +299,7 @@
     "ident": "prep_house",
     "name": "Prepper Household",
     "points": 2,
-    "description": "You knew something was coming, you prepared, when the dead rose, you knew what to do. With your house now barricaded, its time to put your plan into action.",
+    "description": "You knew something was coming, you prepared, when the dead rose, you knew what to do. With your house now barricaded, it's time to put your plan into action.",
     "start_name": "Boarded Up House",
     "professions": [
       "unemployed",
@@ -314,106 +314,54 @@
   },
   {
     "type": "scenario",
-    "ident" : "mutant",
-    "name" : "Experiment",
-    "points" : 2,
-    "description": "Since birth, your sole purpose in life has been the advancement of genetic science, willingly or not.  Once the cataclysm struck, you left the lab, and wandered aimlessly, ending up in a forest.",
-    "start_name" : "Forest",
-    "allowed_locs" : ["forest"],
-    "professions" : ["unemployed","mutant_patient","mutant_volunteer","broken_cyborg"],
-    "traits" : ["ELFAEYES","URSINE_EYE","FANGS","GILLS","SPINES","PLANTSKIN","NAILS","RADIOGENIC","PADDED_FEET","RAP_TALONS","HOOVES","CANINE_EARS","FELINE_EARS","TAIL_FLUFFY","TAIL_LONG","WEB_WALKER","WHISKERS","SLIT_NOSTRILS","TROGLO","WEBBED","BEAK","UNSTABLE","RADIOACTIVE1","SLIMY","HERBIVORE","CARNIVORE","PONDEROUS1","SUNLIGHT_DEPENDENT","COLDBLOOD","GROWL","ARM_FEATHERS","ARM_TENTACLES","LEG_TENTACLES","CHAOTIC","ALCMET","LIGHT_BONES","CHITIN"],
-    "edit-mode" : "modify",
-    "add:professions" : ["faulty_bionic","cykotic"]
-
+    "ident": "mutant",
+    "copy-from": "mutant",
+    "extend": { "professions": [ "faulty_bionic", "cykotic" ] }
   },
   {
     "type": "scenario",
     "ident": "bad_day",
-    "name": "Challenge-Really Bad Day",
-    "points" : -10,
-    "description": "You start drunk to the point of incapacitation, depressed, infected, surrounded by fire, naked, and sick with the flu.  This day went downhill really fast.",
-    "start_name": "Anywhere",
-    "allowed_locs" : ["house","s_grocery","s_gun","s_garage","pawn","bank","mil_surplus","furniture","s_library","s_bookstore"],
-    "professions" : ["svictim","tweaker"],
-    "flags" : ["FIRE_START","INFECTED","BAD_DAY","CHALLENGE"],
-    "edit-mode" : "modify",
-    "add:professions" : ["faulty_bionic","cykotic"]
+    "copy-from": "bad_day",
+    "extend": { "professions": [ "faulty_bionic", "cykotic" ] }
   },
   {
     "type": "scenario",
     "ident": "missed",
-    "name": "Missed",
-    "points" : 0,
-    "description": "Whether due to stubbornness, ignorance, or just plain bad luck, you missed the evacuation, and are stuck in a city full of the risen dead.",
-    "allowed_locs" : ["house","s_grocery","s_gun","s_garage","pawn","bank","mil_surplus","furniture","s_library","s_bookstore","boarded_house"],
-    "start_name": "In Town",
-    "edit-mode" : "modify",
-    "add:allowed_locs" : ["s_electronics_s","s_clothes_s"]
+    "copy-from": "missed",
+    "extend": { "allowed_locs": [ "s_electronics_s", "s_clothes_s" ] }
   },
   {
     "type": "scenario",
-    "ident": "summer_advanced_start",
-    "name": "The Next Summer",
-    "points" : 0,
-    "description": "A little over a year has passed since the apocalypse started, and you're about to face your second summer in Hell.",
-    "allowed_locs" : ["forest","field","cabin"],
-    "start_name": "Outside Town",
-    "flags" : ["SUM_ADV_START"],
-    "professions" : ["naturalist","road_warrior","player_bandit","winter_scavenger","winter_army","waste_ranger","unemployed"],
-    "traits" : ["MARTIAL_ARTS_SURV"],
-    "edit-mode" : "modify"
+    "ident": "missed",
+    "copy-from": "missed",
+    "traits" : ["MARTIAL_ARTS_SURV"]
   },
   {
     "type": "scenario",
-    "name": "Burning Building",
-    "description": "The building you had chosen to reside in has suddenly caught fire!  You might want to leave.",
-    "flags": [ "FIRE_START" ],
     "ident": "fire",
-    "points" : -2,
-    "start_name": "Anywhere",
-    "allowed_locs": [ "house", "s_grocery", "s_gun", "s_garage", "pawn", "bank", "mil_surplus", "furniture", "s_library", "s_bookstore" ],
-    "edit-mode" : "modify",
-    "add:allowed_locs" : ["s_electronics_s","s_clothes_s"]
+    "copy-from": "fire",
+    "extend": { "allowed_locs": [ "s_electronics_s", "s_clothes_s" ] }
   },
   {
     "type": "scenario",
-    "name": "Infected",
-    "description": "In the chaos and panic of evacuation, you got bitten by something!  You didn't get proper medical care, and now the wound has started turning green.",
-    "flags": [ "INFECTED" ],
     "ident": "infected",
-    "points" : -4,
-    "start_name": "Anywhere",
-    "allowed_locs": [ "house", "s_grocery", "s_gun", "s_garage", "pawn", "bank", "mil_surplus", "furniture", "s_library", "s_bookstore" ],
-    "blacklist_professions": true,
-    "professions": [ "medic", "jr_survivalist", "camper", "cyberjunkie" ],
-    "edit-mode" : "modify",
-    "add:allowed_locs" : ["s_electronics_s","s_clothes_s"]
+    "copy-from": "infected",
+    "extend": { "allowed_locs": [ "s_electronics_s", "s_clothes_s" ] }
   },
   {
     "type": "scenario",
     "ident": "ambushed",
-    "name": "Ambush",
-    "points" : 0,
-    "description": "It is the winter after zero hour, cold and weary you ducked into a small cabin for the night.  The next morning, you awoke to the sound of lots of movement in the woods.",
-    "allowed_locs": ["cabin"],
-    "start_name": "Abandoned Cabin",
-    "flags" : ["SUR_START","WIN_START"],
-    "professions" : ["winter_survivor","winter_scavenger","winter_army","unemployed"],
-    "traits" : ["MARTIAL_ARTS_SURV"],
-    "edit-mode" : "modify"
+    "copy-from": "ambushed",
+    "traits" : ["MARTIAL_ARTS_SURV"]
   },
   {
     "type": "scenario",
     "ident": "wilderness",
-    "name": "Wilderness",
-    "points" : 0,
-    "description": "You find yourself amongst trees.  The screaming and the moaning is fainter this far from civilization, but you'd better know what you're doing out here.",
-    "start_name": "Forest",
-    "professions" : ["unemployed", "survivalist", "trapper", "bionic_prepper", "guru", "backpacker", "naturalist", "camper", "bow_hunter", "crossbow_hunter", "shotgun_hunter", "rifle_hunter", "lumberjack", "jr_survivalist", "fisher", "bio_sniper"],
-    "allowed_locs" : ["forest"],
-    "edit-mode" : "modify",
-    "add:professions" : ["pri-sur"],
-    "add:allowed_locs" : ["surv_camp_l"]
+    "copy-from": "wilderness",
+    "extend": {
+      "professions": [ "pri-sur" ],
+      "allowed_locs": [ "surv_camp_l" ]
+    }
   },
   {
     "type": "scenario",
@@ -442,7 +390,7 @@
     "ident": "house_fight_scenario",
     "name": "Slave Fighter's Freedom",
     "points": -2,
-    "description": "All your life you have been experimented and forced to fight others for the amusement of your masters. Never having seen the sun or the outside the cataclysm gave you a chance at freedom. Now you just have to escape from your fellow combatants...",
+    "description": "All your life you have been experimented on and forced to fight others for the amusement of your masters. Never having seen the sun or the outside the cataclysm gave you a chance at freedom. Now you just have to escape from your fellow combatants...",
     "start_name": "Sketchy Cabin",
     "professions": [
       "sf_blade",

--- a/Npc/c_factions.json
+++ b/Npc/c_factions.json
@@ -16,7 +16,7 @@
     "sneak": 0,
     "crime": -1,
     "cult": -1,
-    "description": "Members of the Command Center seeking refuge from...something. They intel and some connections to old guard."
+    "description": "Members of the Command Center seeking refuge from...something. They have intel and some connections to the Old Guard."
   },
   {
     "type": "faction",
@@ -35,7 +35,7 @@
     "sneak": 0,
     "crime": -1,
     "cult": -1,
-    "description": "Ragtag branch of the military that survived the initial cataclysm. Allied to the command center they seek leadership in this new world."
+    "description": "Ragtag branch of the military that survived the initial cataclysm. Allied to the command center, they seek leadership in this new world."
   },
   {
     "type": "faction",
@@ -54,7 +54,7 @@
     "sneak": 0,
     "crime": -1,
     "cult": -1,
-    "description": "Survivors who had prepared for the cataclysm before the idea of it was on the radar. They posses the means to rebuild."
+    "description": "Survivors who had prepared for the cataclysm before the idea of it was on the radar. They possess the means to rebuild."
   },
   {
     "type": "faction",
@@ -92,7 +92,7 @@
     "sneak": 0,
     "crime": 1,
     "cult": 0,
-    "description": "People who all their lives have been nothing but fighting in a ring for the amusement of the rich.  Most of the saner captives and new meat end up in Blue Team, pitted against hardened and \"broken in\" combatants."
+    "description": "People who all their lives have seen nothing but fighting in a ring for the amusement of the rich.  Most of the saner captives and new meat end up in Blue Team, pitted against hardened and \"broken in\" combatants."
   },
   {
     "type": "faction",
@@ -111,6 +111,6 @@
     "sneak": 0,
     "crime": 1,
     "cult": 0,
-    "description": "People who all their lives have been nothing but fighting in a ring for the amusement of the rich. Devoid of reason they think the cataclysm is but another round, barely able to tell each other apart from the other team."
+    "description": "People who all their lives have seen nothing but fighting in a ring for the amusement of the rich. Devoid of reason they think the cataclysm is but another round, barely able to tell each other apart from the other team."
   }
 ]

--- a/Surv_help/c_armor.json
+++ b/Surv_help/c_armor.json
@@ -11,7 +11,7 @@
     "to_hit": 0,
     "storage": 50,
     "symbol": "[",
-    "description": "A custom-built backpack modified furthered to be an archer's best friend. Lots of storage, manageable encumbrance and a built in quiver.",
+    "description": "A custom-built backpack modified further to be an archer's best friend. Lots of storage, manageable encumbrance and a built in quiver.",
     "price": 36000,
     "material": [
       "leather",
@@ -60,7 +60,7 @@
     "to_hit": -3,
     "storage": 80,
     "symbol": "[",
-    "description": "A home-made suit build to live off the land. Comes with ample storage, warm fur lining, environmental and physical protection, a built-in watch, a built in gasmask and a makeshift sheath ring. This suit looks very good on you, in a post-cataclysmic sort of way.",
+    "description": "A home-made suit built to live off the land. Comes with ample storage, warm fur lining, environmental and physical protection, a built-in watch, a built in gasmask and a makeshift sheath ring. This suit looks very good on you, in a post-cataclysmic sort of way.",
     "price": 180000,
     "material": [
       "leather",
@@ -130,7 +130,7 @@
     "to_hit": -3,
     "storage": 80,
     "symbol": "[",
-    "description": "A home-made suit build to live off the land. Comes with ample storage, warm fur lining, environmental and physical protection, a built in watch, a built in gasmask and a makeshift sheath ring. The suit is carefully crafted of Kevlar fabric and reinforced in metal. This suit looks very good on you, in a post-cataclysmic sort of way.",
+    "description": "A home-made suit built to live off the land. Comes with ample storage, warm fur lining, environmental and physical protection, a built in watch, a built in gasmask and a makeshift sheath ring. The suit is carefully crafted of Kevlar fabric and reinforced in metal. This suit looks very good on you, in a post-cataclysmic sort of way.",
     "price": 180000,
     "material": [
       "kevlar",
@@ -399,7 +399,7 @@
     "to_hit": -3,
     "storage": 0,
     "symbol": "[",
-    "description": "A full-body suit of grey bulletproof armor. Somewhat 'easy' to move in by having joints jointed by leather.",
+    "description": "A full-body suit of grey bulletproof armor. Somewhat 'easy' to move in, having joints protected by leather.",
     "price": 350000,
     "material": [
       "kevlar",

--- a/Surv_help/c_bionics.json
+++ b/Surv_help/c_bionics.json
@@ -54,7 +54,7 @@
     "act_cost": 100,
     "gun_bionic": true,
     "fake_item": "bio_laser_minigun",
-    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a multiple lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand."
+    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a barrage of lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand."
   },
   {
     "type": "BIONIC_ITEM",
@@ -63,7 +63,7 @@
     "symbol": ":",
     "color": "yellow",
     "name": "Laser Gatling Arm CBM",
-    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a multiple lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
+    "description": "Your left arm has been replaced by a rapid fire laser gatling gun!  You may use your energy banks to fire a barrage of lasers.  However, you are unable to use or carry two-handed items, and your strength limits what you can use with your one hand.",
     "price": 220000,
     "material": [
       "steel",

--- a/Surv_help/c_martialarts.json
+++ b/Surv_help/c_martialarts.json
@@ -42,7 +42,7 @@
         "unarmed_allowed": true,
         "min_unarmed": 2,
         "throw_immune": true,
-        "description": "If thrown or knockdown the user rolls slightly and gets up before an attack can be dealt."
+        "description": "If thrown or knocked down the user rolls slightly, and gets up before an attack can be dealt."
       }
     ],
     "onattack_buffs": [

--- a/Surv_help/c_martialartsbook.json
+++ b/Surv_help/c_martialartsbook.json
@@ -5,7 +5,7 @@
     "type": "GENERIC",
     "name": "Survivor Combatives",
     "name_plural": "Survivor Combatives",
-    "description": "A journal with a tutorial on various unorhtodox combat mechanics.",
+    "description": "A journal with a tutorial on various unorthodox combat mechanics.",
     "book_data": {
       "max_level": 5,
       "intelligence": 8,

--- a/Surv_help/c_tools.json
+++ b/Surv_help/c_tools.json
@@ -153,7 +153,7 @@
     "symbol": ",",
     "name": "Survival in a Can",
     "name_plural": "Survival in a Cans",
-    "description": "A large tin can held together by a tab and seal. Remove the seal to split the can into two smaller can and reveal its contents. It contains carefully packed survival items with a list of them on the side of the can. You could not possibly put its contents back together.",
+    "description": "A large tin can held together by a tab and seal. Remove the seal to split the container into two smaller cans and reveal its contents. It contains carefully packed survival items with a list of them on the side of the can. You could not possibly put its contents back together.",
     "price": 600,
     "material": "steel",
     "flags": [
@@ -311,7 +311,7 @@
     "symbol": ";",
     "color": "light_gray",
     "name": "Can Forge (off)",
-    "description": "This is a portable light source/forge/food cooker made from a soda can with pebbles reinforcing the inner wall, powered by charcoal. It is used to meltdown metals, cook some food and providing low light for crafting.",
+    "description": "This is a portable light source/forge/food cooker made from a soda can with pebbles reinforcing the inner wall, powered by charcoal. It is used to melt down metals, cook some food and providing low light for crafting.",
     "price": 1000,
     "material": [
       "aluminum",
@@ -393,7 +393,7 @@
     "color": "light_gray",
     "symbol": ";",
     "name": "metal mold",
-    "description": "This is a plastic mold.  It could be shaped and used to craft items made of metal.",
+    "description": "This is a makeshift mold made from plastic.  It could be shaped and used to craft items made of metal.",
     "price": 1000,
     "material": "plastic",
     "weight": 4,
@@ -413,7 +413,7 @@
     "symbol": ";",
     "color": "grey",
     "name": "Molded Hammer",
-    "description": "This is a molded metal hammer with a metal handle.  It functions like a professional hammer but it is bulkier and weights more adding a little bashing power",
+    "description": "This is a molded metal hammer with a metal handle.  It functions like a professional hammer but it is bulkier and weighs more, adding a little bashing power",
     "price": 500,
     "material": [
       "steel"
@@ -446,7 +446,7 @@
     "symbol": ";",
     "color": "light_gray",
     "name": "Molded Knife",
-    "name_plural": "stone knives",
+    "name_plural": "Molded Knives",
     "description": "This is a sharpened molded metal blade with a metal handle.  Works better than sharpening any old metal.",
     "price": 200,
     "material": [
@@ -693,7 +693,7 @@
     "symbol": "/",
     "color": "white",
     "name": "Fishing String",
-    "description": "A long string with a hook attached to the end. Useful as a crude fishing tool. Requires Bait as lure and sinker.",
+    "description": "A long string with a hook attached to the end. Useful as a crude fishing tool. Requires bait as lure and sinker.",
     "price": 0,
     "material": "cotton",
     "weight": 170,
@@ -717,7 +717,7 @@
     "color": "brown",
     "name": "Solar torch",
     "name_plural": "Solar torches",
-    "description": "A mysterious torch that uses the power of the sun (and blob goo) to lit itself. Somehow, the gasoline synthesized goo produces gasoline when in the sun continuously soaking the rag making it 'rechargeable' in a sense. You need a lighter to turn it on. One lit, it can't be turned off until all fuel is used.",
+    "description": "A mysterious torch that uses the power of the sun (and blob goo) to light itself. Somehow, the gasoline synthesized goo produces gasoline when in the sun continuously soaking the rag making it 'rechargeable' in a sense. You need a lighter to turn it on. Once lit, it can't be turned off until all fuel is used.",
     "price": 0,
     "material": "wood",
     "weight": 956,
@@ -752,7 +752,7 @@
     "color": "brown",
     "name": "Solar torch (lit)",
     "name_plural": "Solar torches (lit)",
-    "description": "A mysterious torch that uses the power of the sun (and blob goo) to lit itself. Somehow, the gasoline synthesized goo produces gasoline when in the sun continuously soaking the rag making it 'rechargeable' in a sense. It is burning, producing plenty of light, now to wait for it to run out of fuel.",
+    "description": "A mysterious torch that uses the power of the sun (and blob goo) to ligt itself. Somehow, the gasoline synthesized goo produces gasoline when in the sun continuously soaking the rag making it 'rechargeable' in a sense. It is burning, producing plenty of light, now to wait for it to run out of fuel.",
     "price": 0,
     "material": "wood",
     "flags": [
@@ -813,7 +813,7 @@
     "symbol": ";",
     "color": "brown",
     "name": "Molded Saw",
-    "description": "A Molded saw that somewhat combines the utilities of a wood and metal saws.",
+    "description": "A Molded saw that somewhat combines the utilities of wood and metal saws.",
     "price": 3000,
     "material": [
       "steel"
@@ -863,7 +863,7 @@
       "terrain": [
         "Survivor_Holdout"
       ],
-      "message": "After putting off for a while, you memorize the location..."
+      "message": "After putting it off for a while, you memorize the location..."
     }
   },
   {
@@ -917,7 +917,7 @@
     "symbol": ";",
     "color": "blue",
     "name": "Encampment project reminder",
-    "description": "A note describing a group of people creating prepper settlements. You try to remember if there is any of them nearby. Maybe the back of the note has coordinates to their settlements.",
+    "description": "A note describing a group of people creating prepper settlements. You try to remember if there are any of them nearby. Maybe the back of the note has coordinates to their settlements.",
     "price": 0,
     "material": "paper",
     "weight": 30,
@@ -942,7 +942,7 @@
     "color": "brown",
     "name": "Hammer Multi-tool",
     "name_plural": "Hammer Multi-tools",
-    "description": "A multi-tool who's top is a hammer and a pair of pliers combined. Small and practical, the survivor's mini-tool-kit.",
+    "description": "A multi-tool whose top is a hammer and a pair of pliers combined. Small and practical, the survivor's mini-tool-kit.",
     "price": 5000,
     "material": [
       "steel",

--- a/Weapons/c_ranged.json
+++ b/Weapons/c_ranged.json
@@ -275,7 +275,7 @@
     "symbol": "(",
     "color": "yellow",
     "name": "ARC-314 laser carbine",
-    "description": "An experimental laser carbine based on the A7. Compact, powerful and low ups consumption make it an improvement over its predecessor, even if it rattles a bit when fired. Features a fixed holographic sight that swivels aside and behind it more rail for another sight. Its manufacturer is unknown.",
+    "description": "An experimental laser carbine based on the A7. Compact, powerful and low UPS consumption make it an improvement over its predecessor, even if it rattles a bit when fired. Features a fixed holographic sight that swivels aside and behind it more rail for another sight. Its manufacturer is unknown.",
     "price": 1800000,
     "material": [
       "steel",
@@ -496,7 +496,7 @@
     "color": "yellow",
     "symbol": "(",
     "name": "Survivor's UPS Rifle",
-    "description": "A rifle that converts UPS energy into pure laser. Uses 20 UPS charges per shot. Advance electronics prevent jams and makes it double as a turret. Futuristic survivor technology.",
+    "description": "A rifle that converts UPS energy into pure laser firepower. Uses 20 UPS charges per shot. Advanced electronics prevent jams and make it double as a turret. Futuristic survivor technology.",
     "price": 358000,
     "material": [
       "steel",
@@ -563,7 +563,7 @@
     "color": "yellow",
     "symbol": "(",
     "name": "Survivor's Crank Rifle",
-    "description": "Somehow, after many days of research...you created it. A simple conversion now that you thing about it...Replace the motor of your UPS Rifle with a foot crank and bam... infinite ammo... lower performance, lower turret ability and jams are but small setbacks...",
+    "description": "Somehow, after many days of research...you created it. A simple conversion now that you think about it...Replace the motor of your UPS Rifle with a foot crank and bam... infinite ammo... lower performance, lower turret ability and jams are but small setbacks...",
     "price": 749000,
     "material": [
       "steel",
@@ -629,7 +629,7 @@
     "color": "light_red",
     "symbol": "{",
     "name": "Survivor's Battery Pistol",
-    "description": "A simple electronic pistol. Draws the power from batteries and shoots it. Although weak, it shocks the target.",
+    "description": "A simple electronic pistol. Draws power from batteries and shoots it. Although weak, it shocks the target.",
     "price": 42400,
     "material": [
       "steel",
@@ -687,7 +687,7 @@
     "color": "light_red",
     "symbol": "{",
     "name": "Survivor's Battery Rifle",
-    "description": "An electronic rifle. Draws the power from batteries and shoots it. Its complexity may cause jams. Still weak but has higher damage than its pistol variant, it still shocks the target.",
+    "description": "An electronic rifle. Draws power from batteries and shoots it. Its complexity may cause jams. Still weak but has higher damage than its pistol variant, it still shocks the target.",
     "price": 87100,
     "material": [
       "steel",
@@ -757,7 +757,7 @@
     "color": "brown",
     "name": "Survivor's .223 Assault Rifle",
     "name_plural": "Survivor's .223 Assault Rifles",
-    "description": "A (mostly) homemade assault rifle built from a full auto receiver. While still lower quality over pre-cataclysm rifles, its superior to many other homemade weapons. Takes the .223 cartridge via its magazine",
+    "description": "A (mostly) homemade assault rifle built from a full auto receiver.  While still lower quality over pre-cataclysm rifles, it's superior to many other homemade weapons.  Takes the .223 cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -853,7 +853,7 @@
     "color": "brown",
     "name": "Survivor's .22 SMG",
     "name_plural": "Survivor's .22 SMGs",
-    "description": "A (mostly) homemade SMG built from a full auto receiver. While still lower quality over pre-cataclysm SMGs, its superior to many other homemade weapons. Takes the .22 cartridge via its magazine",
+    "description": "A (mostly) homemade SMG built from a full auto receiver.  While still lower quality over pre-cataclysm SMGs, it's superior to many other homemade weapons.  Takes the .22 cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -932,7 +932,7 @@
     "color": "brown",
     "name": "Survivor's 9mm SMG",
     "name_plural": "Survivor's 9mm SMGs",
-    "description": "A (mostly) homemade SMG built from a full auto receiver. While still lower quality over pre-cataclysm SMGs, its superior to many other homemade weapons. Takes the 9mm cartridge via its magazine.",
+    "description": "A (mostly) homemade SMG built from a full auto receiver.  While still lower quality over pre-cataclysm SMGs, it's superior to many other homemade weapons.  Takes the 9mm cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -1011,7 +1011,7 @@
     "color": "brown",
     "name": "Survivor's .45 SMG",
     "name_plural": "Survivor's .45 SMGs",
-    "description": "A (mostly) homemade SMG built from a full auto receiver. While still lower quality over pre-cataclysm SMGs, its superior to many other homemade weapons. Takes the .45 cartridge via its magazine.",
+    "description": "A (mostly) homemade SMG built from a full auto receiver.  While still lower quality over pre-cataclysm SMGs, it's superior to many other homemade weapons.  Takes the .45 cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -1090,7 +1090,7 @@
     "color": "brown",
     "name": "Survivor's .308 Assault Rifle",
     "name_plural": "Survivor's .308 Assault Rifles",
-    "description": "A (mostly) homemade assault rifle built from a full auto receiver. While still lower quality over pre-cataclysm rifles, its superior to many other homemade weapons. Takes the .308 cartridge via its magazine.",
+    "description": "A (mostly) homemade assault rifle built from a full auto receiver.  While still lower quality over pre-cataclysm rifles, it's superior to many other homemade weapons.  Takes the .308 cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -1186,7 +1186,7 @@
     "color": "brown",
     "name": "Survivor's 7.62x39 Assault Rifle",
     "name_plural": "Survivor's 7.62x39 Assault Rifles",
-    "description": "A (mostly) homemade assault rifle built from a full auto receiver. While still lower quality over pre-cataclysm rifles, its superior to many other homemade weapons. Takes the 7.62x39 cartridge.",
+    "description": "A (mostly) homemade assault rifle built from a full auto receiver.  While still lower quality over pre-cataclysm rifles, it's superior to many other homemade weapons.  Takes the 7.62x39 cartridge.",
     "price": 120000,
     "material": [
       "steel",
@@ -1282,7 +1282,7 @@
     "color": "brown",
     "name": "Survivor's Full auto shotgun",
     "name_plural": "Survivor's Full auto shotguns",
-    "description": "A (mostly) homemade full auto shotgun built from a full auto receiver. While still lower quality over pre-cataclysm shotguns, its superior to many other homemade weapons. Takes the .12 gauge cartridge via its magazine.",
+    "description": "A (mostly) homemade full auto shotgun built from a full auto receiver.  While still lower quality over pre-cataclysm shotguns, it's superior to many other homemade weapons.  Takes the 12 gauge cartridge via its magazine.",
     "price": 120000,
     "material": [
       "steel",
@@ -1374,7 +1374,7 @@
     "color": "brown",
     "name": "Survivor's .308 LMG",
     "name_plural": "Survivor's .308 LMGs",
-    "description": "A (mostly) homemade LMG built from a full auto receiver. While still lower quality over pre-cataclysm LMGs, its superior to many other homemade weapons. Takes the .308 cartridge via its magazine.",
+    "description": "A (mostly) homemade LMG built from a full auto receiver.  While still lower quality over pre-cataclysm LMGs, it's superior to many other homemade weapons.  Takes the .308 cartridge via its magazine.",
     "price": 150000,
     "material": [
       "steel",
@@ -1477,7 +1477,7 @@
     "color": "brown",
     "name": "Survivor's 7.62x39 LMG",
     "name_plural": "Survivor's 7.62x39 LMGs",
-    "description": "A (mostly) homemade LMG built from a full auto receiver. While still lower quality over pre-cataclysm LMGs, its superior to many other homemade weapons. Takes the 7.62x39 cartridge via its magazine.",
+    "description": "A (mostly) homemade LMG built from a full auto receiver.  While still lower quality over pre-cataclysm LMGs, it's superior to many other homemade weapons.  Takes the 7.62x39 cartridge via its magazine.",
     "price": 150000,
     "material": [
       "steel",
@@ -1580,7 +1580,7 @@
     "color": "brown",
     "name": "Survivor's .223 LMG",
     "name_plural": "Survivor's .223 LMGs",
-    "description": "A (mostly) homemade LMG built from a full auto receiver. While still lower quality over pre-cataclysm LMGs, its superior to many other homemade weapons. Takes the .223 cartridge via its magazine.",
+    "description": "A (mostly) homemade LMG built from a full auto receiver.  While still lower quality over pre-cataclysm LMGs, it's superior to many other homemade weapons.  Takes the .223 cartridge via its magazine.",
     "price": 150000,
     "material": [
       "steel",
@@ -1682,7 +1682,7 @@
     "symbol": "(",
     "color": "light_brown",
     "name": "Survivor's Fighting Bow",
-    "description": "A powerful bow that requires a strong archer to use. This bow has been designed carefully for accuracy, power and ease of use. The tips of the bow have makeshift blades to make this bow an efficient melee weapon when things get close and personal. Because of the blades, this bow cannot be worn and the only valid mods are sights.",
+    "description": "A powerful bow that requires a strong archer to use.  This bow has been designed carefully for accuracy, power and ease of use.  The tips of the bow have makeshift blades to make this bow an efficient melee weapon when things get close and personal.  Because of the blades, this bow cannot be worn and the only valid mods are sights.",
     "price": 88000,
     "material": [
       "wood",
@@ -1733,7 +1733,7 @@
     "symbol": "(",
     "color": "brown",
     "name": "Survivor's Flintlock Sniper",
-    "description": "The homemade rifle of a true marksman. A long barrelled rifled rifle that shots paper cartridges. Using a straight pull open bolt receiver system makes reloading fairly quick. It uses a lighter's sparker to shoot it's ammunition. Very accurate and damaging but with high recoil, it is meant to shoot targets from afar in rapid succession.",
+    "description": "The homemade rifle of a true marksman.  A long barrelled rifle that shots paper cartridges.  Using a straight pull open bolt receiver system makes reloading fairly quick.  It uses a lighter's sparker to shoot its ammunition.  Very accurate and damaging but with high recoil, it is meant to shoot targets from afar in rapid succession.",
     "price": 52000,
     "material": [
       "iron",
@@ -1810,7 +1810,7 @@
     "symbol": "(",
     "color": "green",
     "name": "repeating crossbow",
-    "description": "A custom-made crossbow with a clever mechanism that loads and fires bolts in a single motion, it has a wooden magazine that holds 10 bolts. Bolts fired from this weapon have a good chance of remaining intact for re-use.",
+    "description": "A custom-made crossbow with a clever mechanism that loads and fires bolts in a single motion, it has a wooden magazine that holds 10 bolts.  Bolts fired from this weapon have a good chance of remaining intact for re-use.",
     "price": 324000,
     "material": [
       "steel",
@@ -1868,7 +1868,7 @@
     "type": "GUN",
     "name": "coilgun",
     "//": "Hard to make, plentiful and cheap ammo, and silent - people will want this thing.",
-    "description": "A homemade gun, using electromagnets to accelerate a ferromagnetic projectile to high velocity. Powered by UPS.",
+    "description": "A homemade gun, using electromagnets to accelerate a ferromagnetic projectile to high velocity.  Powered by UPS.",
     "weight": 3341,
     "volume": 11,
     "price": 75000,
@@ -1916,7 +1916,7 @@
     "override": true,
     "type": "GUN",
     "name": "A7 laser rifle",
-    "description": "A state of the art laser rifle developed by the R&D outfit \"Aerial Labs\".  Initial performance rivaled Rivtech's finest, with rumors flying about corporate skullduggery. Though the cataclysm put that on the ash heap of history, this weapon can still do the same to your foes.",
+    "description": "A state of the art laser rifle developed by the R&D outfit \"Aerial Labs\".  Initial performance rivaled Rivtech's finest, with rumors flying about corporate skullduggery.  Though the cataclysm put that on the ash heap of history, this weapon can still do the same to your foes.",
     "weight": 2950,
     "volume": 12,
     "price": 1600000,
@@ -1977,7 +1977,7 @@
     "override": true,
     "type": "GUN",
     "name": "LACP laser pistol",
-    "description": "The LACP laser pistol was based on the V29 laser pistol designed in the mid-21st century. While little more than duct tape and electronics, it runs on a standard UPS.",
+    "description": "The LACP laser pistol was based on the V29 laser pistol designed in the mid-21st century.  While little more than duct tape and electronics, it runs on a standard UPS.",
     "weight": 540,
     "volume": 8,
     "price": 500000,
@@ -2031,7 +2031,7 @@
     "id": "v29",
     "type": "GUN",
     "name": "V29 laser pistol",
-    "description": "The V29 laser pistol was designed in the mid-21st century and was one of the first firearms to use fusion as its ammunition. It is larger than most traditional handguns, but displays no recoil whatsoever.",
+    "description": "The V29 laser pistol was designed in the mid-21st century and was one of the first firearms to use fusion as its ammunition.  It is larger than most traditional handguns, but displays no recoil whatsoever.",
     "weight": 680,
     "volume": 4,
     "price": 720000,


### PR DESCRIPTION
Started off just running through spelling, grammar, punctuation, spacing, etc for anything that looked off. Then I got to scenarios and saw the overrides to vanilla scenarios used to old, defunct edit-mode thing. Figured fuck it, can fix now before I forget.

* We sell typos and typo accessories (translation: various random fixes)
* Some leftover description single-spaces are culled.
* Few instances of sorta odd or redundant phrasing (rifled rifle) have been messed with. Not like I'm any better with descriptions. :V
* Copy-from set up to fix scenario overrides.

Also, remind me I oughta fiddle with trying NC item overrides for you sometime. D: