### PR TITLE
NC classes for super soldier and bio-hunter NPCs

### DIFF
--- a/Npc/NC_SUPER_SOLDIERS.json
+++ b/Npc/NC_SUPER_SOLDIERS.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "NC_SUPER_SOLDIER_worn",
+    "type": "item_group",
+    "//": "Generic super soldier kit, unisex.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "undershirt" },
+      { "item": "arm_warmers" },
+      { "item": "leg_warmers" },
+      { "item": "pants_army" },
+      { "item": "jacket_army" },
+      { "item": "balclava" },
+      { "item": "beret" },
+      { "item": "gloves_liner" },
+      { "item": "gloves_tactical" },
+      { "item": "socks" },
+      { "item": "boots_combat" }
+    ]
+  },
+  {
+    "id": "NC_SUPER_SOLDIER_carry",
+    "type": "item_group",
+    "//": "Super soldier items. Holy shit NPCs are too dumb to use UPS.",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "militarymap" },
+      { "item": "id_military" },
+      { "item": "stanag30" },
+      { "item": "stanag30" },
+      { "item": "stanag30" }
+    ]
+  },
+  {
+    "id": "NC_SUPER_SOLDIER_weapon",
+    "type": "item_group",
+    "//": "Generic super soldier weapon.  No UPS usage means conventional weapon instead of laser.",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "entries": [
+      { "distribution": [
+        { "item": "acr", "prob": 20 },
+        { "item": "h&k416a5", "prob": 25 },
+        { "item": "m27iar", "prob": 10 },
+        { "item": "m4a1", "prob": 15 },
+        { "item": "scar_l", "prob": 30 }
+      ] }
+    ]
+  },
+  {
+    "id": "NC_BIO_HUNTER_F_worn",
+    "type": "item_group",
+    "//": "Evelynn Rose's kit, mimics player version except for some concessions to using claw mutation instead of CBM.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "bra" },
+      { "item": "panties" },
+      { "item": "undershirt" },
+      { "item": "arm_warmers" },
+      { "item": "leg_warmers" },
+      { "item": "pants_army" },
+      { "item": "jacket_army" },
+      { "item": "balclava" },
+      { "item": "beret" },
+      { "item": "gloves_fingerless" },
+      { "item": "socks" },
+      { "item": "boots_combat" },
+      { "item": "badge_bio_weapon" },
+      { "item": "canteen" }
+    ]
+  },
+  {
+    "id": "NC_BIO_HUNTER_F_carry",
+    "type": "item_group",
+    "//": "Evelynn Rose's items. See above for why a P90 instead of a UPS-powered weapon.",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "mre_veggy_box" },
+      { "item": "biomap" },
+      { "item": "militarymap" },
+      { "item": "fnp90mag" },
+      { "item": "fnp90mag" },
+      { "item": "fnp90mag" }
+    ]
+  },
+  {
+    "id": "NC_BIO_HUNTER_F_weapon",
+    "type": "item_group",
+    "//": "Evelynn Rose's weapon, don't think you can define weapon overrides any other way.  No UPS means conventional firearm instead.",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "entries": [ { "item": "fn_p90" } ]
+  }
+]

--- a/Npc/c_classes.json
+++ b/Npc/c_classes.json
@@ -1,105 +1,6 @@
 [
   {
     "type": "npc_class",
-    "id": "NC_SUPER_SOLDIER",
-    "name": "Super Soldier",
-    "job_description": "I am guarding this place in exchange for food and shelter.",
-    "bonus_str": {
-      "rng": [
-        1,
-        2
-      ]
-    },
-    "bonus_dex": {
-      "rng": [
-        1,
-        2
-      ]
-    },
-    "skills": [
-      {
-        "skill": "ALL",
-        "level": {
-          "sum": [
-            {
-              "dice": [
-                3,
-                2
-              ]
-            },
-            {
-              "constant": 0
-            }
-          ]
-        }
-      },
-      {
-        "skill": "dodge",
-        "bonus": {
-          "rng": [
-            1,
-            2
-          ]
-        }
-      },
-      {
-        "skill": "melee",
-        "bonus": {
-          "rng": [
-            1,
-            2
-          ]
-        }
-      },
-      {
-        "skill": "unarmed",
-        "bonus": {
-          "rng": [
-            1,
-            2
-          ]
-        }
-      },
-      {
-        "skill": "rifle",
-        "bonus": {
-          "rng": [
-            3,
-            5
-          ]
-        }
-      },
-      {
-        "skill": "gun",
-        "bonus": {
-          "rng": [
-            2,
-            4
-          ]
-        }
-      },
-      {
-        "skill": "cutting",
-        "bonus": {
-          "rng": [
-            1,
-            2
-          ]
-        }
-      },
-      {
-        "skill": "stabbing",
-        "bonus": {
-          "rng": [
-            1,
-            2
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "type": "npc_class",
     "id": "NC_BIO_WEAPON",
     "name": "Bio Weapon",
     "job_description": "I am here to find answers...",
@@ -208,6 +109,90 @@
         }
       }
     ]
+    },
+    {
+        "type" : "npc_class",
+        "id" : "NC_SUPER_SOLDIER",
+        "name" : "Super Soldier",
+        "job_description" : "I am guarding this place in exchange for food and shelter.",
+        "common" : false,
+        "bonus_str" : { "rng" : [ 1, 2 ] },
+        "bonus_dex" : { "rng" : [ 1, 2 ] },
+        "skills" : [
+            {
+                "skill" : "ALL", "level" : {
+                    "mul" : [
+                        { "one_in" : 3 },
+                        {
+                            "sum" : [
+                                { "dice" : [ 2, 2 ] },
+                                { "constant": -2 }
+                            ]
+                        }
+                    ]
+                }
+            },
+            { "skill": "dodge", "bonus" : { "rng" : [ 1, 2 ] } },
+            { "skill": "melee", "bonus" : { "rng" : [ 1, 2 ] } },
+            { "skill": "unarmed", "bonus" : { "rng" : [ 1, 2 ] } },
+            { "skill": "rifle", "bonus" : { "rng" : [ 3, 5 ] } },
+            { "skill": "gun", "bonus" : { "rng" : [ 2, 4 ] } },
+            { "skill": "cutting", "bonus" : { "rng" : [ 1, 2 ] } },
+            { "skill": "stabbing", "bonus" : { "rng" : [ 1, 2 ] } }
+        ],
+        "worn_override": "NC_SUPER_SOLDIER_worn",
+        "carry_override": "NC_SUPER_SOLDIER_carry",
+        "weapon_override": "NC_SUPER_SOLDIER_weapon",
+        "comment": "Some traits to mimic a few of the profession bionics.",
+        "traits": [
+            [ "SUPER_SOLDIER_MARKER", 100 ],
+            [ "THICKSKIN", 100 ],
+            [ "NIGHTVISION", 100 ],
+            [ "ADRENALINE", 100 ],
+            [ "REGEN", 100 ]
+        ]
+    },
+    {
+        "type" : "npc_class",
+        "id" : "NC_BIO_HUNTER_F",
+        "name" : "Bio-Weapon Hunter",
+        "job_description" : "I am here to fix this mess.",
+        "common" : false,
+        "bonus_str" : { "rng" : [ 1, 3 ] },
+        "bonus_dex" : { "rng" : [ 1, 3 ] },
+        "skills" : [
+            {
+                "skill" : "ALL", "level" : {
+                    "mul" : [
+                        { "one_in" : 3 },
+                        {
+                            "sum" : [
+                                { "dice" : [ 2, 3 ] },
+                                { "constant": -2 }
+                            ]
+                        }
+                    ]
+                }
+            },
+            { "skill": "dodge", "bonus" : { "rng" : [ 1, 3 ] } },
+            { "skill": "melee", "bonus" : { "rng" : [ 1, 3 ] } },
+            { "skill": "unarmed", "bonus" : { "rng" : [ 1, 3 ] } },
+            { "skill": "smg", "bonus" : { "rng" : [ 3, 6 ] } },
+            { "skill": "gun", "bonus" : { "rng" : [ 2, 5 ] } },
+            { "skill": "cutting", "bonus" : { "rng" : [ 1, 3 ] } },
+            { "skill": "stabbing", "bonus" : { "rng" : [ 1, 3 ] } }
+        ],
+        "worn_override": "NC_BIO_HUNTER_F_worn",
+        "carry_override": "NC_BIO_HUNTER_F_carry",
+        "weapon_override": "NC_BIO_HUNTER_F_weapon",
+        "comment": "Some traits to mimic a few of the profession bionics.",
+        "traits": [
+            [ "SUPER_SOLDIER_MARKER", 100 ],
+            [ "THICKSKIN", 100 ],
+            [ "NIGHTVISION", 100 ],
+            [ "CLAWS", 100 ],
+            [ "REGEN", 100 ]
+        ]
   },
     {
         "type" : "npc_class",

--- a/Npc/c_npc.json
+++ b/Npc/c_npc.json
@@ -7,7 +7,7 @@
     "gender": "male",
     "class": "NC_SCAVENGER",
     "attitude": 1,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_BFF",
     "faction": "preppers"
   },
@@ -30,9 +30,9 @@
     "name_unique" : "Evelynn Rose",
     "name_suffix": "Bio Hunter",
     "gender": "female",
-    "class": "NC_SOLDIER",
+    "class": "NC_BIO_HUNTER_F",
     "attitude": 1,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_BHUNTER",
     "faction": "super_soldiers"
   },
@@ -45,7 +45,7 @@
     "gender": "male",
     "class": "NC_SCIENTIST",
     "attitude": 0,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_MSCI",
     "faction": "commandeers"
   },
@@ -58,7 +58,7 @@
     "gender": "male",
     "class": "NC_SOLDIER",
     "attitude": 0,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_BIO_1",
     "faction": "bio_weapons"
   },
@@ -71,7 +71,7 @@
     "gender": "female",
     "class": "NC_SOLDIER",
     "attitude": 0,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_BIO_2",
     "faction": "bio_weapons"
   },
@@ -81,9 +81,9 @@
     "comment": "One of the Guards in the Command Center.",
     "name_suffix": "Super Soldier",
     "gender": "female",
-    "class": "NC_SOLDIER",
+    "class": "NC_SUPER_SOLDIER",
     "attitude": 0,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_CGUARD1",
     "faction": "commandeers"
   },
@@ -93,9 +93,9 @@
     "comment": "One of the Guards in the Command Center.",
     "name_suffix": "Super Soldier",
     "gender": "male",
-    "class": "NC_SOLDIER",
+    "class": "NC_SUPER_SOLDIER",
     "attitude": 0,
-    "mission": 0,
+    "mission": 7,
     "chat": "TALK_CGUARD2",
     "faction": "commandeers"
   },

--- a/Terrain/makeshift_command_center.json
+++ b/Terrain/makeshift_command_center.json
@@ -167,7 +167,7 @@
         { "class": "main_bio_sci", "x": 20, "y": 22 },
         { "class": "bio_weapon_1", "x": 22, "y": 10 },
         { "class": "bio_weapon_2", "x": 22, "y": 14 },
-        { "class": "cmnd_guard_1", "x": 15, "y": 4 },
+        { "class": "cmnd_guard_1", "x": 15, "y": 5 },
         { "class": "cmnd_guard_2", "x": 19, "y": 4 }
       ]
     }


### PR DESCRIPTION
As usual, tell me if I done derped, and anything that I can add that'll improve things.

* Set up the two super-soldier NPCs and the bio-hunter NPC to have working NC classes. Should be a rough mockup of what seems to be the idea in the older unused super-soldier class. Mostly modeled off of the professions except for piling on traits best as I could to replace CBMs, and one annoying thing I encountered below.
* Also switched these static NPCs to use mission 7 (guard) instead of 0 so they'll stay put like good little pests, instead of wandering around looting the place.
* And told the female super-soldier to stop dancing on the pool table. :V

Fun annoying problem I discovered, NPCs are too stupid to figure out how to use a UPS, so I couldn't give them the laser carbines. Went with a P90 for the bio-hunter and a random selection of STANAG-fed rifles for the 2 super-soldiers. Add "NPCs that can use a fucking UPS" to my wishlist. ;w;

Next on my plan list is I guess the two bio-weapon NPCs. I'd guess Trigger's an alpha (conversation entries don't hint at any intended specialty), but none of the available professions seem to match Blade's self-described mixed role of being good with both ranged and melee. Okay I guess the power-armor one counts, but that has the same issue I've already run into...