### PR TITLE
Adds prepper camp NC classes

### DIFF
--- a/Npc/NC_PREPPERS.json
+++ b/Npc/NC_PREPPERS.json
@@ -9,7 +9,7 @@
           { "item": "undershirt", "prob": 30 },
           { "item": "kevlar", "prob": 10 },
           { "item": "long_undertop", "prob": 30 },
-          { "items": "under_armor", "prob": 30 }
+          { "item": "under_armor", "prob": 30 }
         ]
       },
       {
@@ -17,7 +17,7 @@
           { "group": "male_underwear_bottom", "prob": 30 },
           { "group": "loincloth", "prob": 10 },
           { "item": "long_underpants", "prob": 30 },
-          { "items": "under_armor_shorts", "prob": 30 }
+          { "item": "under_armor_shorts", "prob": 30 }
         ]
       },
       {

--- a/Npc/NC_PREPPERS.json
+++ b/Npc/NC_PREPPERS.json
@@ -1,0 +1,236 @@
+[
+  {
+    "id": "NC_PREPPER_worn",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "undershirt", "prob": 30 },
+          { "item": "kevlar", "prob": 10 },
+          { "item": "long_undertop", "prob": 30 },
+          { "items": "under_armor", "prob": 30 }
+        ]
+      },
+      {
+        "distribution": [
+          { "group": "male_underwear_bottom", "prob": 30 },
+          { "group": "loincloth", "prob": 10 },
+          { "item": "long_underpants", "prob": 30 },
+          { "items": "under_armor_shorts", "prob": 30 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "socks", "prob": 45 },
+          { "item": "socks_wool", "prob": 45 },
+          { "item": "footrags", "prob": 10 }
+        ]
+      },
+      { "item": "gloves_liner", "prob": 50 },
+      {
+        "distribution": [
+          { "group": "NC_PREPPER_worn_normal", "prob": 50 },
+          { "group": "NC_PREPPER_worn_nomad", "prob": 10 },
+          { "group": "NC_PREPPER_worn_scav", "prob": 10 },
+          { "group": "NC_PREPPER_worn_survivor", "prob": 10 },
+          { "group": "NC_PREPPER_worn_lmil", "prob": 5 },
+          { "item": "surv_suit", "prob": 10 },
+          { "item": "surv_armor_suit", "prob": 5 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_worn_nomad",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "armor_nomad" },
+      { "item": "helmet_nomad" },
+      { "group": "NC_SCAVENGER_gloves" },
+      {
+        "distribution": [
+          { "item": "boots", "prob": 40 },
+          { "item": "boots_hiking", "prob": 30 },
+          { "item": "boots_steel", "prob": 30 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_worn_scav",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "armor_scavenger" },
+      { "item": "helmet_scavenger" },
+      { "group": "NC_SCAVENGER_gloves" },
+      {
+        "distribution": [
+          { "item": "boots", "prob": 40 },
+          { "item": "boots_hiking", "prob": 30 },
+          { "item": "boots_steel", "prob": 30 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_worn_survivor",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      { "item": "lsurvivor_armor" },
+      { "item": "duster_survivor" },
+      { "item": "gloves_lsurvivor", "prob": 50 },
+      { "item": "hood_lsurvivor" },
+      { "item": "mask_lsurvivor", "prob": 50 },
+      { "item": "lsurvivor_pants" },
+      { "item": "boots_lsurvivor" }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_worn_lmil",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "lmil_armor" },
+      { "item": "mask_lsurvivor", "prob": 50 },
+      {
+        "distribution": [
+          { "item": "backpack", "prob": 30 },
+          { "item": "slingpack", "prob": 30 },
+          { "item": "survivor_pack", "prob": 20 },
+          { "item": "survbowpack", "prob": 20 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_worn_normal",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "clothing_outdoor_torso" },
+      { "group": "clothing_outdoor_pants" },
+      { "group": "clothing_outdoor_shoes" },
+      {
+        "distribution": [
+          { "item": "backpack", "prob": 30 },
+          { "item": "slingpack", "prob": 30 },
+          { "item": "survivor_pack", "prob": 20 },
+          { "item": "survbowpack", "prob": 20 }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry",
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "And this is how to reliably get NC overrides to pair guns and ammo.",
+    "entries": [
+      { "group": "NC_PREPPER_carry_pnu", "prob": 20 },
+      { "group": "NC_PREPPER_carry_batt", "prob": 10 },
+      { "group": "NC_PREPPER_carry_223", "prob": 10 },
+      { "group": "NC_PREPPER_carry_9mm", "prob": 10 },
+      { "group": "NC_PREPPER_carry_bow", "prob": 30 },
+      { "group": "NC_PREPPER_carry_flint", "prob": 20 }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_pnu",
+    "type": "item_group",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      {
+        "distribution": [
+          { "item": "sling", "prob": 20 },
+          { "item": "wristrocket", "prob": 10 },
+          { "item": "bullet_crossbow", "prob": 20 },
+          { "item": "tihar", "prob": 25 },
+          { "item": "sur_pnu_lmg", "prob": 25 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "bearing", "prob": 30, "count": [ 2, 3 ] },
+          { "item": "marble", "prob": 30, "count": [ 2, 3 ] },
+          { "item": "pebble", "prob": 40, "count": [ 2, 3 ] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_batt",
+    "type": "item_group",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "surv_battery_rifle" },
+      { "item": "battery", "count": [ 1, 2 ] }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_223",
+    "type": "item_group",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "entries": [
+      { "item": "surv_full_223" },
+      { "item": "surv_223_mag", "count": [ 2, 3 ] }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "entries": [
+      { "item": "surv_full_9mm" },
+      { "item": "surv_9mm_mag", "count": [ 2, 3 ] }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_bow",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "longbow", "prob": 40 },
+          { "item": "compbow", "prob": 40 },
+          { "item": "survbow", "prob": 30 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "arrow_wood", "prob": 50, "count": [ 1, 3 ] },
+          { "item": "arrow_wood_heavy", "prob": 30, "count": [ 1, 3 ] },
+          { "item": "arrow_metal_sharpened_fletched", "prob": 20, "count": [ 1, 3 ] },
+          { "item": "arrow_metal", "prob": 20, "count": [ 1, 3 ] }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "NC_PREPPER_carry_flint",
+    "type": "item_group",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      {
+        "distribution": [
+          { "item": "carbine_flintlock", "prob": 30 },
+          { "item": "carbine_flintlock_double", "prob": 40 },
+          { "item": "rifle_flintlock", "prob": 30 },
+          { "item": "surv_sniper", "prob": 40 }
+        ]
+      },
+      { "item": "flintlock_ammo", "count": [ 1, 2 ] }
+    ]
+  }
+]

--- a/Npc/c_classes.json
+++ b/Npc/c_classes.json
@@ -112,6 +112,36 @@
     },
     {
         "type" : "npc_class",
+        "id" : "NC_PREPPER",
+        "name" : "Prepper",
+        "job_description" : "Just surviving, as usual.",
+        "common" : false,
+        "bonus_str" : { "rng" : [ -1, 1 ] },
+        "bonus_int" : { "rng" : [ -1, 1 ] },
+        "bonus_dex" : { "rng" : [ -1, 2 ] },
+        "bonus_per" : { "rng" : [ -1, 2 ] },
+        "skills" : [
+            {
+                "skill" : "ALL", "level" : {
+                    "sum" : [
+                        { "dice" : [ 3, 2 ] },
+                        { "constant" : -3 }
+                    ]
+                }
+            },
+            { "skill": "survival", "bonus" : { "rng" : [ 2, 4 ] } },
+            { "skill": "gun", "bonus" : { "rng" : [ 2, 4 ] } },
+            { "skill": "pistol", "bonus" : { "rng" : [ 2, 5 ] } },
+            { "skill": "rifle", "bonus" : { "rng" : [ 0, 3 ] } },
+            { "skill": "archery", "bonus" : { "rng" : [ 0, 3 ] } }
+        ],
+        "comment": "Weapon is empty group to workaround difficulty pairing weapons and ammo via overrides.",
+        "worn_override": "NC_PREPPER_worn",
+        "carry_override": "NC_PREPPER_carry",
+        "weapon_override": "EMPTY_GROUP"
+    },
+    {
+        "type" : "npc_class",
         "id" : "NC_SUPER_SOLDIER",
         "name" : "Super Soldier",
         "job_description" : "I am guarding this place in exchange for food and shelter.",

--- a/Npc/c_npc.json
+++ b/Npc/c_npc.json
@@ -14,10 +14,20 @@
   {
     "type": "npc",
     "id": "survn",
+    "comment": "Static encampment NPCs",
+    "name_suffix": "Prepper",
+    "class": "NC_PREPPER",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_SHELTER",
+    "faction": "preppers"
+  },
+  {
+    "type": "npc",
+    "id": "survn_special",
     "comment": "Use as a random NPC encounter",
     "name_suffix": "Prepper",
-    "gender": "male",
-    "class": "NC_SCAVENGER",
+    "class": "NC_PREPPER",
     "attitude": 0,
     "mission": 0,
     "chat": "TALK_SHELTER",

--- a/Surv_help/c_item_groups.json
+++ b/Surv_help/c_item_groups.json
@@ -2051,5 +2051,19 @@
         10
       ]
     ]
+  },
+  {
+    "id": "dead_slave_fighters",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "group": "NC_GLADIATOR_LIGHT_worn", "prob": 50 },
+          { "group": "NC_GLADIATOR_HEAVY_worn", "prob": 50 }
+        ]
+      },
+      { "item": "corpse" }
+    ]
   }
 ]

--- a/Terrain/forest_slaughter.json
+++ b/Terrain/forest_slaughter.json
@@ -47,6 +47,9 @@
         "_": "f_null",
         "t": "f_null"
       },
+      "place_loot": [
+        { "group": "dead_slave_fighters", "x": [ 1, 22 ], "y": [ 9, 12 ], "repeat": [ 2, 5 ] }
+      ],
       "place_npcs": [
         { "class": "slave_fight", "x": 11, "y": 13 }
       ]

--- a/Terrain/surv_camp.json
+++ b/Terrain/surv_camp.json
@@ -78,7 +78,7 @@
         { "item": "forest", "x": 1, "y": 10, "chance": 75 }
       ],
       "place_npcs": [
-        { "class": "survn", "x": 4, "y": 4 }
+        { "class": "survn_special", "x": 4, "y": 4 }
       ]
     }
   }

--- a/Terrain/surv_emcampnp.json
+++ b/Terrain/surv_emcampnp.json
@@ -132,11 +132,7 @@
         { "class": "survn", "x": 4, "y": 16 },
         { "class": "survn", "x": 17, "y": 16 },
         { "class": "survn", "x": 10, "y": 6 },
-        { "class": "survn", "x": 11, "y": 11 },
-        { "class": "survn", "x": 13, "y": 2 },
-        { "class": "survn", "x": 12, "y": 10 },
         { "class": "survn", "x": 13, "y": 7 },
-        { "class": "survn", "x": 11, "y": 8 },
         { "class": "survn", "x": 10, "y": 15 }
       ],
       "place_vehicles": [


### PR DESCRIPTION
* Added the prepper NC files so that the friendly encampments get a little more flavor to them. Large usage of Noct stuff.
* Separated the static NPCs in the encampment to the one in the hidden camp that'll wander off to pick up stuff. Maybe also made them random in sex, just for flavor.
* Small nerf to the population of friendly encampments, given they might now be loot piñatas (at least for ammo) if you can kill them all.
* Random change to the forest slave fight area, having found it while searching for preppers. Basically just littered their area with random dead gladiators, 2-5.

Eventually plan to give the surv_camp guys that pretend to be dynamic NPCs some dialogue, assuming it doesn't suck like my dialogue ideas tend to. :V