### PR TITLE
Rebalanced some mutagen recipes.

### DIFF
--- a/Recipe/c_recipes.json
+++ b/Recipe/c_recipes.json
@@ -5947,5 +5947,143 @@
         ]
       ]
     ]
-  }
+  },
+  {
+  "type" : "recipe",
+  "override": true,
+  "result": "mutagen_alpha",
+  "category": "CC_CHEM",
+  "subcategory": "CSC_CHEM_MUTAGEN",
+  "skill_used": "cooking",
+  "skills_required": [ "firstaid", 1 ],
+  "difficulty": 10,
+  "time": 20000,
+  "book_learn": [[ "recipe_alpha", 9 ]],
+  "qualities":[
+    {"id":"CHEM","level":2}
+  ], "tools": [
+    [ [ "surface_heat", 50, "LIST" ] ]
+  ],
+  "components": [
+    [
+      [ "mutagen", 1 ]
+    ],
+    [
+      [ "purifier", 1 ]
+    ],
+    [
+      [ "human_flesh", 3 ],
+      [ "dry_hflesh", 3 ],
+      [ "fetus", 1 ],
+      [ "arm", 1 ],
+      [ "leg", 1 ]
+    ],
+    [
+      [ "bone_human", 1 ],
+      [ "blood", 1 ]
+    ],
+    [
+      [ "ammonia", 1 ],
+      [ "lye_powder", 100 ]
+    ]
+  ]
+},{
+  "type" : "recipe",
+  "override": true,
+  "result": "mutagen_elfa",
+  "category": "CC_CHEM",
+  "subcategory": "CSC_CHEM_MUTAGEN",
+  "skill_used": "cooking",
+  "skills_required": [ "firstaid", 1 ],
+  "difficulty": 10,
+  "time": 12500,
+  "book_learn": [[ "recipe_elfa", 10 ]],
+  "qualities":[
+    {"id":"CHEM","level":2}
+  ], "tools": [
+    [ [ "surface_heat", 31, "LIST" ] ]
+  ],
+  "components": [
+    [
+      [ "mutagen", 1 ]
+    ],
+    [
+      [ "veggy", 3 ],
+      [ "biollante_bud", 1 ],
+      [ "datura_seed", 16 ]
+    ],
+    [
+      [ "meat", 3 ]
+    ],
+    [
+      [ "ammonia", 1 ],
+      [ "lye_powder", 100 ]
+    ]
+  ]
+},{
+  "type" : "recipe",
+  "override": true,
+  "result": "mutagen_chimera",
+  "category": "CC_CHEM",
+  "subcategory": "CSC_CHEM_MUTAGEN",
+  "skill_used": "cooking",
+  "skills_required": [ "firstaid", 1 ],
+  "difficulty": 10,
+  "time": 15000,
+  "book_learn": [[ "recipe_chimera", 9]],
+  "qualities":[
+    {"id":"CHEM","level":2}
+  ], "tools": [
+    [ [ "surface_heat", 37, "LIST" ] ]
+  ],
+  "components": [
+    [
+      [ "mutagen", 1 ]
+    ],
+	[
+      [ "egg_reptile", 1 ]
+    ],
+    [
+      [ "egg_bird", 1 ]
+    ],
+    [
+      [ "meat", 6 ]
+    ],
+    [
+      [ "ammonia", 1 ],
+      [ "lye_powder", 100 ]
+    ]
+  ]
+},{
+  "type" : "recipe",
+  "override": true,
+  "result": "mutagen_raptor",
+  "category": "CC_CHEM",
+  "subcategory": "CSC_CHEM_MUTAGEN",
+  "skill_used": "cooking",
+  "skills_required": [ "firstaid", 1 ],
+  "difficulty": 10,
+  "time": 12500,
+  "book_learn": [[ "recipe_raptor", 9 ]],
+  "qualities":[
+    {"id":"CHEM","level":2}
+  ], "tools": [
+    [ [ "surface_heat", 31, "LIST" ] ]
+  ],
+  "components": [
+    [
+      [ "mutagen", 1 ]
+    ],
+	[
+      [ "egg_reptile", 1 ]
+    ],
+    [
+      [ "egg_bird", 1 ]
+    ],
+    [
+      [ "ammonia", 1 ],
+      [ "lye_powder", 100 ]
+    ]
+  ]
+}
 ]

--- a/Weapons/c_ranged.json
+++ b/Weapons/c_ranged.json
@@ -2029,6 +2029,7 @@
   },
   {
     "id": "v29",
+    "override": true,
     "type": "GUN",
     "name": "V29 laser pistol",
     "description": "The V29 laser pistol was designed in the mid-21st century and was one of the first firearms to use fusion as its ammunition.  It is larger than most traditional handguns, but displays no recoil whatsoever.",


### PR DESCRIPTION
Rebalanced alpha ,elf-a, chimera, and raptor mutagen recipes.
These recipes where extremely expensive to the point where you needed to know and have ingredients for other mutagens for them to work. I change this by making them take ingredients either used in the other mutagens instead of an entire mutagen and in the case of alpha make it so you require human meat.

This way you can focus on just learning this recipes if you want to focus on them and only have to focus on their ingredients rather than having to make other mutagens for them.

P.S: Added a missing `override:true` to the V29 item.